### PR TITLE
🝏 Remove the unused variable 'str' from the 'arg.c' file.

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -724,7 +724,6 @@ STR ***retary;
     register STR **sarg;
     int max = 9;
     register int i;
-    STR *str;
 
     ary = myarray;
     if (!ary)


### PR DESCRIPTION
The compiler gives a warning.
```
arg.c: In function ‘do_time’:
arg.c:727:10: warning: unused variable ‘str’ [-Wunused-variable]
  727 |     STR *str;
      |          ^~~
```