### PR TITLE
🜝 Include '<stdio.h>' in the 'version.c' file.

### DIFF
--- a/version.c
+++ b/version.c
@@ -6,6 +6,7 @@
  * 
  */
 
+#include <stdio.h>
 #include "patchlevel.h"
 
 /* Print out the version number. */


### PR DESCRIPTION
The compiler gives a warning.
```
version.c:10:1: note: include ‘<stdio.h>’ or provide a declaration of ‘printf’
    9 | #include "patchlevel.h"
  +++ |+#include <stdio.h>
   10 |
```