### PR TITLE
Remove the unused variable 'arg' from the 'cmd.c' file.

### DIFF
--- a/cmd.c
+++ b/cmd.c
@@ -50,7 +50,6 @@ register CMD *cmd;
     register int cmdflags;
     register bool match;
     register char *go_to = goto_targ;
-    ARG *arg;
     FILE *fp;
 
     retstr = &str_no;


### PR DESCRIPTION
The compiler gives a warning.
```
cmd.c:53:10: warning: unused variable ‘arg’ [-Wunused-variable]
   53 |     ARG *arg;
      |          ^~~
```
