### PR TITLE
🝡 Remove the unused variable 'ch' from the 'arg.c' file.

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -593,7 +593,6 @@ do_tell(stab)
 STAB *stab;
 {
     register STIO *stio;
-    int ch;
 
     if (!stab)
 	return -1L;


### PR DESCRIPTION
The compiler gives a warning.
```
arg.c: In function ‘do_tell’:
arg.c:596:9: warning: unused variable ‘ch’ [-Wunused-variable]
  596 |     int ch;
      |         ^~
```
