### PR TITLE
🜌 Add a declaration of function 'str_len' to a header file.

### DIFF
--- a/str.h
+++ b/str.h
@@ -33,3 +33,5 @@ double str_2num();
 STR *str_static();
 STR *str_make();
 STR *str_nmake();
+int str_len(register STR *);
+


### PR DESCRIPTION
Eliminate similar compiler warnings.
```
arg.c:210:24: warning: implicit declaration of function ‘str_len’; did you mean ‘strnlen’? [-Wimplicit-function-declaration]
  210 |         dstr = str_new(str_len(str));
      |                        ^~~~~~~
      |                        strnlen
```
```
array.c:194:16: warning: implicit declaration of function ‘str_len’; did you mean ‘strnlen’? [-Wimplicit-function-declaration]
  194 |         len += str_len(ar->ary_array[i]);
      |                ^~~~~~~
      |                strnlen
```
```
form.c:212:20: warning: implicit declaration of function ‘str_len’; did you mean ‘strnlen’? [-Wimplicit-function-declaration]
  212 |             size = str_len(str);
      |                    ^~~~~~~
      |                    strnlen
```