### PR TITLE
🝮 Add parentheses around an assignment in the function 'do_subst'.

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -111,8 +111,8 @@ register ARG *arg;
 	if (debug & 8)
 	    deb("2.SPAT /%s/\n",t);
 #endif
-	if (d = compile(&spat->spat_compex,t,TRUE,
-	  spat->spat_flags & SPAT_FOLD )) {
+	if ((d = compile(&spat->spat_compex,t,TRUE,
+	  spat->spat_flags & SPAT_FOLD ))) {
 	    fatal("/%s/: %s", t, d);
 	    return FALSE;
 	}


### PR DESCRIPTION
Eliminate a further compiler warning.
```
arg.c:114:13: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
  114 |         if (d = compile(&spat->spat_compex,t,TRUE,
      |             ^
arg.c: In function ‘do_subst’:
```