### PR TITLE
🝨 Add parentheses around an assignment in the function 'do_subst'.

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -182,8 +182,8 @@ register ARG *arg;
 	char *d;
 
 	m = str_get(eval(spat->spat_runtime,Null(STR***)));
-	if (d = compile(&spat->spat_compex,m,TRUE,
-	  spat->spat_flags & SPAT_FOLD )) {
+	if ((d = compile(&spat->spat_compex,m,TRUE,
+	  spat->spat_flags & SPAT_FOLD ))) {
 	    fatal("/%s/: %s", m, d);
 	    return 0;
 	}


### PR DESCRIPTION
Yet another assignment is missing parentheses. Eliminate the compiler warning below.
```
arg.c: In function ‘do_subst’:
arg.c:185:13: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
  185 |         if (d = compile(&spat->spat_compex,m,TRUE,
      |             ^
```