### PR TITLE
🝖 Add parentheses around an assignment in the function 'do_subst'.

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -204,7 +204,7 @@ register ARG *arg;
 	  strnNE(spat->spat_first->str_ptr, s, spat->spat_flen) )
 	    return 0;
     }
-    if (m = execute(&spat->spat_compex, s, TRUE, 1)) {
+    if ((m = execute(&spat->spat_compex, s, TRUE, 1))) {
 	int iters = 0;
 
 	dstr = str_new(str_len(str));


### PR DESCRIPTION
Eliminate a compiler warning.
```
arg.c: In function ‘do_subst’:
arg.c:207:9: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
  207 |     if (m = execute(&spat->spat_compex, s, TRUE, 1)) {
      |         ^
```