### PR TITLE
🜔 Add a declaration of function 'str_ncat' to a header file.

### DIFF
--- a/str.c
+++ b/str.c
@@ -180,6 +180,7 @@ register char *ptr;
     str->str_pok = 1;		/* validate pointer */
 }
 
+void
 str_ncat(str,ptr,len)
 register STR *str;
 register char *ptr;

--- a/str.h
+++ b/str.h
@@ -34,4 +34,5 @@ STR *str_static();
 STR *str_make();
 STR *str_nmake();
 int str_len(register STR *);
+void str_ncat(register STR *, register char *, register int);
 


### PR DESCRIPTION
Eliminate some compiler warnings about the 'str_ncat' function. An example warning is:
```
arg.c: In function ‘do_subst’:
arg.c:219:13: warning: implicit declaration of function ‘str_ncat’; did you mean ‘strncat’? [-Wimplicit-function-declaration]
  219 |             str_ncat(dstr,s,m-s);
      |             ^~~~~~~~
      |             strncat
``` 