### PR TITLE
🜔 Add a declaration of function 'str_scat' to a header file.

### DIFF
--- a/str.c
+++ b/str.c
@@ -196,6 +196,7 @@ register int len;
     str->str_pok = 1;		/* validate pointer */
 }
 
+void
 str_scat(dstr,sstr)
 STR *dstr;
 register STR *sstr;

--- a/str.h
+++ b/str.h
@@ -35,4 +35,5 @@ STR *str_make();
 STR *str_nmake();
 int str_len(register STR *);
 void str_ncat(register STR *, register char *, register int);
+void str_scat(STR *, register STR *);
 


### PR DESCRIPTION
Here's yet another compiler warning to eliminate.
```
arg.c: In function ‘do_subst’:
arg.c:221:13: warning: implicit declaration of function ‘str_scat’; did you mean ‘str_ncat’? [-Wimplicit-function-declaration]
  221 |             str_scat(dstr,eval(spat->spat_repl,Null(STR***)));
      |             ^~~~~~~~
      |             str_ncat
```