### PR TITLE
☄🜼🜧🜲 Add parentheses around an assignment in the function 'do_subst'.

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -221,7 +221,7 @@ register ARG *arg;
 	    str_scat(dstr,eval(spat->spat_repl,Null(STR***)));
 	    if (spat->spat_flags & SPAT_USE_ONCE)
 		break;
-	} while (m = execute(&spat->spat_compex, s, FALSE, 1));
+	} while ((m = execute(&spat->spat_compex, s, FALSE, 1)));
 	str_cat(dstr,s);
 	str_replace(str,dstr);
 	STABSET(str);


### PR DESCRIPTION
Fix yet another compiler warning. It'll be a routine fix.
```
arg.c: In function ‘do_subst’:
arg.c:224:18: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
  224 |         } while (m = execute(&spat->spat_compex, s, FALSE, 1));
      |                  ^
```
