### PR TITLE
🜍🜏🜎🜵 Add a declaration of function 'str_cat' to a header file.

### DIFF
--- a/str.h
+++ b/str.h
@@ -36,4 +36,5 @@ STR *str_nmake();
 int str_len(register STR *);
 void str_ncat(register STR *, register char *, register int);
 void str_scat(STR *, register STR *);
+void str_cat(register STR *, register char *);
 


### PR DESCRIPTION
Eliminate a warning caused by a missing declaration.
```
arg.c: In function ‘do_subst’:
arg.c:225:9: warning: implicit declaration of function ‘str_cat’; did you mean ‘str_scat’? [-Wimplicit-function-declaration]
  225 |         str_cat(dstr,s);
      |         ^~~~~~~
      |         str_scat
```