### PR TITLE
🜍🜓🝃🝗 Add a declaration of function 'str_replace' to a header file.

### DIFF
--- a/str.h
+++ b/str.h
@@ -37,4 +37,5 @@ int str_len(register STR *);
 void str_ncat(register STR *, register char *, register int);
 void str_scat(STR *, register STR *);
 void str_cat(register STR *, register char *);
+void str_replace(register STR *, register STR *);
 


### PR DESCRIPTION
Here's yet another missing declaration to add.
```
arg.c: In function ‘do_subst’:
arg.c:226:9: warning: implicit declaration of function ‘str_replace’ [-Wimplicit-function-declaration]
  226 |         str_replace(str,dstr);
      |         ^~~~~~~~~~~
```