### PR TITLE
🝅🜚🜿🝰 Add a declaration of function 'arg_free' to a header file.

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -80,6 +80,7 @@
 
 #include "EXTERN.h"
 #include "perl.h"
+#include "perly.h"
 
 #include <signal.h>
 

--- a/perly.c
+++ b/perly.c
@@ -57,6 +57,8 @@ char rcsid[] = "$Header: perly.c,v 1.0.1.11 88/03/10 16:42:59 root Exp $";
  * 
  */
 
+#include "perly.h"
+
 bool preprocess = FALSE;
 bool minus_n = FALSE;
 bool minus_p = FALSE;
@@ -2724,7 +2726,7 @@ register CMD *cmd;
 	    break;
 	case C_EXPR:
 	    if (cmd->ucmd.acmd.ac_stab)
-		arg_free(cmd->ucmd.acmd.ac_stab);
+		arg_free((ARG *)cmd->ucmd.acmd.ac_stab);
 	    if (cmd->ucmd.acmd.ac_expr)
 		arg_free(cmd->ucmd.acmd.ac_expr);
 	    break;
@@ -2737,6 +2739,7 @@ register CMD *cmd;
     }
 }
 
+void
 arg_free(arg)
 register ARG *arg;
 {

--- a/perly.h
+++ b/perly.h
@@ -1,0 +1,2 @@
+void arg_free(register ARG *);
+


### PR DESCRIPTION
Fix two compiler warnings at a time.
```
arg.c: In function ‘do_split’:
arg.c:290:13: warning: implicit declaration of function ‘arg_free’ [-Wimplicit-function-declaration]
  290 |             arg_free(spat->spat_runtime);       /* it won't change, so */
      |      
```
```
perly.c: In function ‘cmd_free’:
perly.c:2729:40: warning: passing argument 1 of ‘arg_free’ from incompatible pointer type [-Wincompatible-pointer-types]
 2729 |                 arg_free(cmd->ucmd.acmd.ac_stab);
      |                          ~~~~~~~~~~~~~~^~~~~~~~
      |                                        |
      |                                        STAB * {aka struct stab *}
```