### PR TITLE
🝐🝪🜒🜋 Add parentheses around an assignment in the function 'do_trans'.

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -251,7 +251,7 @@ register ARG *arg;
     }
 #endif
     while (*s) {
-	if (ch = tbl[*s & 0377]) {
+	if ((ch = tbl[*s & 0377])) {
 	    matches++;
 	    *s = ch;
 	}


### PR DESCRIPTION
Remove yet another compiler warning, as usual.
```
arg.c: In function ‘do_trans’:
arg.c:254:13: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
  254 |         if (ch = tbl[*s & 0377]) {
      |             ^~
```