### PR TITLE
Add parentheses around an assignment in the function 'do_split'.

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -291,8 +291,8 @@ STR ***retary;
 	    arg_free(spat->spat_runtime);	/* it won't change, so */
 	    spat->spat_runtime = Nullarg;	/* no point compiling again */
 	}
-	if (d = compile(&spat->spat_compex,m,TRUE,
-	  spat->spat_flags & SPAT_FOLD )) {
+	if ((d = compile(&spat->spat_compex,m,TRUE,
+	  spat->spat_flags & SPAT_FOLD ))) {
 	    fatal("/%s/: %s", m, d);
 	    return FALSE;
 	}


### PR DESCRIPTION
```
arg.c: In function ‘do_split’:
arg.c:294:13: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
  294 |         if (d = compile(&spat->spat_compex,m,TRUE,
      |             ^
```