### PR TITLE
Remove an unused label.

### DIFF
--- a/util.c
+++ b/util.c
@@ -36,8 +36,6 @@ static char nomem[] = "Out of memory!\n";
 
 /* paranoid version of malloc */
 
-static int an = 0;
-
 char *
 safemalloc(size)
 MEM_SIZE size;


### PR DESCRIPTION
Make this warning go away.
```
util.c: At top level:
util.c:39:12: warning: ‘an’ defined but not used [-Wunused-variable]
   39 | static int an = 0;
      |            ^~
```