### PR TITLE
All compiler warnings are fixed.

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -83,6 +83,7 @@
 #include "perly.h"
 
 #include <signal.h>
+#include <sys/wait.h>
 
 ARG *debarg;
 
@@ -622,6 +623,7 @@ int whence;
     return fseek(stio->fp, pos, whence) >= 0;
 }
 
+int
 do_stat(arg,sarg,retary)
 register ARG *arg;
 register STR **sarg;
@@ -678,6 +680,7 @@ STR ***retary;
     return max;
 }
 
+int
 do_tms(retary)
 STR ***retary;
 {
@@ -714,6 +717,7 @@ STR ***retary;
     return max;
 }
 
+int
 do_time(tmbuf,retary)
 struct tm *tmbuf;
 STR ***retary;
@@ -960,6 +964,7 @@ register ARRAY *ary;
     return str;
 }
 
+void
 do_unshift(arg,ary)
 register ARG *arg;
 register ARRAY *ary;
@@ -983,6 +988,7 @@ register ARRAY *ary;
     safefree((char*)tmpary);
 }
 
+int
 apply(type,arg,sarg)
 int type;
 register ARG *arg;
@@ -1070,7 +1076,7 @@ STR **sarg;
 STR *
 do_subr(arg,sarg)
 register ARG *arg;
-register char **sarg;
+register STR **sarg;
 {
     ARRAY *savearray;
     STR *str;
@@ -1168,7 +1174,7 @@ STR ***retary;
     ary->ary_fill = -1;
 
     hiterinit(hash);
-    while (entry = hiternext(hash)) {
+    while ((entry = hiternext(hash)) != NULL) {
 	max++;
 	if (kv == O_KEYS)
 	    apush(ary,str_make(hiterkey(entry)));
@@ -1226,8 +1232,6 @@ STR ***retary;
 void
 init_eval()
 {
-    register int i;
-
 #define A(e1,e2,e3) (e1+(e2<<1)+(e3<<2))
     opargs[O_ITEM] =		A(1,0,0);
     opargs[O_ITEM2] =		A(0,0,0);
@@ -2165,7 +2169,8 @@ STR ***retary;		/* where to return an array to, null if nowhere */
 	value = (double)fork();
 	goto donumset;
     case O_SYSTEM:
-	if (anum = vfork()) {
+	anum = vfork();
+	if (anum) {
 	    ihand = signal(SIGINT, SIG_IGN);
 	    qhand = signal(SIGQUIT, SIG_IGN);
 	    while ((maxarg = wait(&argflags)) != anum && maxarg != -1)
@@ -2424,7 +2429,6 @@ freeargs:
     }
     return str;
 
-nullarray:
     maxarg = 0;
 #ifdef DEBUGGING
     dlevel--;

--- a/array.h
+++ b/array.h
@@ -26,4 +26,5 @@ bool apush();
 long alen();
 ARRAY *anew();
 void aunshift(register ARRAY *, register int);
+void ajoin(register ARRAY *, char *, register STR *);
 

--- a/form.h
+++ b/form.h
@@ -27,3 +27,16 @@ struct formcmd {
 #define FC_MORE 4
 
 #define Nullfcmd Null(FCMD*)
+
+struct outrec {
+    int o_lines;
+    char *o_str;
+    int o_len;
+};
+
+EXT struct outrec outrec;
+EXT struct outrec toprec;
+
+void format(register struct outrec *, register FCMD *);
+void do_write(struct outrec *, register STIO *);
+

--- a/perl.h
+++ b/perl.h
@@ -168,15 +168,6 @@ void freearg();
 EXT int line INIT(0);
 EXT int arybase INIT(0);
 
-struct outrec {
-    int o_lines;
-    char *o_str;
-    int o_len;
-};
-
-EXT struct outrec outrec;
-EXT struct outrec toprec;
-
 EXT STAB *last_in_stab INIT(Nullstab);
 EXT STAB *defstab INIT(Nullstab);
 EXT STAB *argvstab INIT(Nullstab);

--- a/str.h
+++ b/str.h
@@ -39,4 +39,8 @@ void str_sset(STR *, register STR *);
 void str_set(register STR *, register char *);
 void str_numset(register STR *, double);
 void str_chop(register STR *, register char *);
+void str_inc(register STR *);
+void str_dec(register STR *);
+void str_reset(register char *);
+void str_grow(register STR *, int);
 


### PR DESCRIPTION
Now Perl 1 builds with no compiler warning. It passes all valid tests as well. I've fixed the compiler warnings listed below.
```
arg.c:625:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  625 | do_stat(arg,sarg,retary)
      | ^~~~~~~
arg.c:681:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  681 | do_tms(retary)
      | ^~~~~~
arg.c:717:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  717 | do_time(tmbuf,retary)
      | ^~~~~~~
arg.c:963:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  963 | do_unshift(arg,ary)
      | ^~~~~~~~~~
arg.c:986:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  986 | apply(type,arg,sarg)
      | ^~~~~
arg.c: In function ‘do_subr’:
arg.c:1084:26: warning: passing argument 2 of ‘str_sset’ from incompatible pointer type [-Wincompatible-pointer-types]
 1084 |         str_sset(str,sarg[1]);
      |                      ~~~~^~~
      |                          |
      |                          char *
In file included from perl.h:83,
                 from arg.c:82:
str.h:38:22: note: expected ‘STR *’ {aka ‘struct string *’} but argument is of type ‘char *’
   38 | void str_sset(STR *, register STR *);
      |                      ^~~~~~~~~~~~~~
arg.c: In function ‘do_kv’:
arg.c:1171:12: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
 1171 |     while (entry = hiternext(hash)) {
      |            ^~~~~
arg.c: In function ‘init_eval’:
arg.c:1229:18: warning: unused variable ‘i’ [-Wunused-variable]
 1229 |     register int i;
      |                  ^
arg.c: In function ‘eval’:
arg.c:1463:21: warning: implicit declaration of function ‘str_inc’ [-Wimplicit-function-declaration]
 1463 |                     str_inc(str);
      |                     ^~~~~~~
arg.c:1465:21: warning: implicit declaration of function ‘str_dec’; did you mean ‘str_new’? [-Wimplicit-function-declaration]
 1465 |                     str_dec(str);
      |                     ^~~~~~~
      |                     str_new
arg.c:1800:9: warning: implicit declaration of function ‘format’ [-Wimplicit-function-declaration]
 1800 |         format(&outrec,form);
      |         ^~~~~~
arg.c:1801:9: warning: implicit declaration of function ‘do_write’ [-Wimplicit-function-declaration]
 1801 |         do_write(&outrec,stab->stab_io);
      |         ^~~~~~~~
arg.c:1949:13: warning: implicit declaration of function ‘ajoin’ [-Wimplicit-function-declaration]
 1949 |             ajoin(arg[2].arg_ptr.arg_stab->stab_array,str_get(sarg[1]),str);
      |             ^~~~~
arg.c:2022:9: warning: implicit declaration of function ‘str_reset’; did you mean ‘str_set’? [-Wimplicit-function-declaration]
 2022 |         str_reset(str_get(sarg[1]));
      |         ^~~~~~~~~
      |         str_set
arg.c:2168:13: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
 2168 |         if (anum = vfork()) {
      |             ^~~~
arg.c:2171:30: warning: implicit declaration of function ‘wait’ [-Wimplicit-function-declaration]
 2171 |             while ((maxarg = wait(&argflags)) != anum && maxarg != -1)
      |                              ^~~~
arg.c:2427:1: warning: label ‘nullarray’ defined but not used [-Wunused-label]
 2427 | nullarray:
      | ^~~~~~~~~
arg.c: In function ‘do_unshift’:
arg.c:984:1: warning: control reaches end of non-void function [-Wreturn-type]
  984 | }
      | ^
cc -c -fpcc-struct-return -Wall -O  array.c
array.c: In function ‘ajoin’:
array.c:195:5: warning: implicit declaration of function ‘str_grow’ [-Wimplicit-function-declaration]
  195 |     str_grow(str,len);                  /* preallocate for efficiency */
      |     ^~~~~~~~
```